### PR TITLE
Add 'language_settings' endpoint with query parameter for language code

### DIFF
--- a/api_cod/request.php
+++ b/api_cod/request.php
@@ -283,6 +283,19 @@ switch ($get) {
         };
         break;
 
+    case 'language_settings':
+        $query = <<<SQL
+            SELECT DISTINCT *
+            FROM language_settings
+        SQL;
+        // ---
+        $tab = add_li_params($query, [], $endpoint_params);
+        // ---
+        $query = $tab['qua'];
+        $params = $tab['params'];
+        // ---
+        break;
+
     case 'publish_reports_stats':
         $query = <<<SQL
             SELECT DISTINCT YEAR(date) as year, MONTH(date) as month, lang, user, result

--- a/endpoint_params.json
+++ b/endpoint_params.json
@@ -12,6 +12,11 @@
             { "name": "distinct", "column": "distinct", "type": "switch", "no_select": true }
         ]
     },
+    "language_settings": {
+        "params": [
+            { "name": "lang_code", "column": "lang_code", "type": "text", "placeholder": "Language code"}
+        ]
+    },
     "publish_reports_stats": {
         "params": []
     },

--- a/openapi.json
+++ b/openapi.json
@@ -1543,6 +1543,31 @@
                     }
                 }
             }
+        },
+        "/api.php?get=language_settings": {
+            "get": {
+                "summary": "language settings",
+                "description": "",
+                "tags": [
+                    "other"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "lang_code",
+                        "description": "Language code",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/Success"
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new API endpoint to retrieve language settings, with optional filtering by language code. This endpoint is now documented and available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->