### PR TITLE
Migrate exists_by_qids_query from all_articles to category_members

### DIFF
--- a/src/api_cod/subs/missing_exists.php
+++ b/src/api_cod/subs/missing_exists.php
@@ -18,7 +18,7 @@ function exists_by_qids_query($endpoint_params)
     /*
         [
             { "name": "lang", "column": "t.code", "type": "text", "placeholder": "Language code", "no_mt_options": true },
-            { "name": "category", "column": "aa.category", "type": "text", "placeholder": "Category", "no_mt_options": true },
+            { "name": "category", "column": "cm.category", "type": "text", "placeholder": "Category", "no_mt_options": true },
             { "name": "campaign", "column": "campaign", "type": "text", "placeholder": "Campaign" },
             { "name": "order", "column": "order", "type": "text", "placeholder": "Order by", "no_select": true }
         ]
@@ -28,12 +28,12 @@ function exists_by_qids_query($endpoint_params)
         SELECT
             t.qid AS qid,
             q.title AS title,
-            aa.category AS category,
+            cm.category AS category,
             t.code AS code,
             t.target AS target
         FROM qids q
-            JOIN all_qids_exists t      ON t.qid = q.qid
-            LEFT JOIN all_articles aa   ON aa.article_id = q.title
+            JOIN all_qids_exists t        ON t.qid = q.qid
+            LEFT JOIN category_members cm ON cm.article_id = q.title
         WHERE t.code = ?
 
         AND (t.target != '' AND t.target IS NOT NULL)
@@ -56,10 +56,10 @@ function exists_by_qids_query($endpoint_params)
     $category   = sanitize_input($category_raw ?? '', '/^[A-Za-z0-9-]+$/');
     // ---
     if ($category === null && $campaign !== null) {
-        $qua .= " AND aa.category IN (SELECT category FROM categories WHERE campaign = ?)";
+        $qua .= " AND cm.category IN (SELECT category FROM categories WHERE campaign = ?)";
         $params[] = $campaign;
     } elseif ($category !== null) {
-        $qua .= " AND aa.category = ?";
+        $qua .= " AND cm.category = ?";
         $params[] = $category;
     }
     // ---


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @MrIbrahem :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Phase 2 of the `all_articles` → `category_members` migration

Implements the rewrite recommended for `exists_by_qids_query` in [`docs/all_articles_migration_audit.md`](https://github.com/Mdwiki-TD/TD_API/blob/audit/all-articles-migration-report/docs/all_articles_migration_audit.md) (PR #42), bringing the last `all_articles` reader in this repo in line with the convention already used by the four neighbouring functions in the same file.

### Change

`src/api_cod/subs/missing_exists.php` — `exists_by_qids_query`:

- `LEFT JOIN all_articles aa ON aa.article_id = q.title` → `LEFT JOIN category_members cm ON cm.article_id = q.title`
- `aa.category` → `cm.category` in the SELECT list, in the optional `category = ?` filter, and in the optional `category IN (... WHERE campaign = ?)` filter
- Doc-comment column hint updated to `cm.category`

### Behaviour

- **With `category=` or `campaign=` filter:** identical result set. The WHERE clause continues to act as an effective inner-join, returning one row per (qid, code) for articles in the matching category.
- **Without a category/campaign filter:** an article that is a member of N categories will now appear N times instead of once. This matches the cardinality the four neighbouring functions in this file already produce against `category_members`. If the consumer turns out to need the original "1 row per article" shape, we can wrap the join in a `GROUP BY article_id` subquery in a follow-up — keeping this PR a pure column/table substitution.

### Verification

Ran locally inside the sandbox:

```
$ vendor/bin/phpstan analyse
 [OK] No errors

$ vendor/bin/phpunit tests --testdox
Tests: 97, Assertions: 147 — OK
```

(The 206 PHPUnit doc-comment-metadata deprecation notices are pre-existing and unrelated to this change.)

After this PR no live code under `src/` references `all_articles`. The schema in `sql.sql` is intentionally left in place; dropping it is Phase 4 and only happens after the Translation-Dashboard and mdwiki-python-files PRs are merged and observed.

### Companion PRs

- Mdwiki-TD/Translation-Dashboard — same rewrite for the verbatim copy of `exists_by_qids_query` in `new_sql_tables.php`
- Mdwiki-TD/mdwiki-python-files — Phase 1 (the three `mdcount/*.py` SELECTs and the redundant `to_sql` write) and Phase 3 (re-pointing `fix_it_db.py` at the `words` table)